### PR TITLE
remove hard-coded version string from req header

### DIFF
--- a/lib/bitpay/client.rb
+++ b/lib/bitpay/client.rb
@@ -50,7 +50,7 @@ module BitPay
       request.basic_auth @api_key, ''
       request['User-Agent'] = USER_AGENT
       request['Content-Type'] = 'application/json'
-      request['X-BitPay-Plugin-Info'] = 'Rubylib0.1.2'
+      request['X-BitPay-Plugin-Info'] = 'Rubylib' + VERSION
       request.body = params.to_json
       response = @https.request request
       JSON.parse response.body


### PR DESCRIPTION
Use the gem version constant instead of the string existing in
multiple places. This will prevent confusion in case the client
version is bumped but the request header gets missed. This could lead
to potential confusion if Bitpay ever needs to debug version of Ruby
client used to access the API.
