### PR TITLE
Refactor: create rest_connector module

### DIFF
--- a/config/constants.rb
+++ b/config/constants.rb
@@ -11,9 +11,9 @@ TEST_PASS = ENV['RCTESTPASSWORD']
 DASHBOARD_URL = "#{ROOT_ADDRESS}/dashboard/merchant/home"
 
 unless
-	ROOT_ADDRESS &&
-	TEST_USER &&
-	TEST_PASS
+  ROOT_ADDRESS &&
+  TEST_USER &&
+  TEST_PASS
 then
-	raise "Missing configuration options - see constants.rb"
+  raise "Missing configuration options - see constants.rb"
 end

--- a/features/step_definitions/keygen_steps.rb
+++ b/features/step_definitions/keygen_steps.rb
@@ -61,5 +61,5 @@ Given(/^the user requests a client\-side pairing$/) do
 end
 
 Then(/^they will receive a claim code$/) do
-  expect(@response["data"].first["pairingCode"] ).not_to be_empty
+  expect(@response.first["pairingCode"] ).not_to be_empty
 end

--- a/features/step_definitions/step_helpers.rb
+++ b/features/step_definitions/step_helpers.rb
@@ -66,7 +66,7 @@ def new_client_from_stored_values
 end
 
 def get_token_from_file
-  token = JSON.parse(File.read(BitPay::TOKEN_FILE_PATH))['data'][0]
+  token = JSON.parse(File.read(BitPay::TOKEN_FILE_PATH))[0]
   {token['facade'] => token['token']}
 end
 

--- a/lib/bitpay/rest_connector.rb
+++ b/lib/bitpay/rest_connector.rb
@@ -1,0 +1,96 @@
+# license Copyright 2011-2015 BitPay, Inc., MIT License
+# see http://opensource.org/licenses/MIT
+# or https://github.com/bitpay/php-bitpay-client/blob/master/LICENSE
+
+module BitPay
+  module RestConnector
+    def send_request(verb, path, facade: 'merchant', params: {}, token: nil)
+      token ||= get_token(facade)
+      case verb.upcase
+      when "GET"
+        return get(path: path, token:token)
+      when "POST"
+        return post(path: path, token: token, params: params)
+      else
+        raise(BitPayError, "Invalid HTTP verb: #{verb.upcase}")
+      end
+    end
+
+    def get(path:, token: nil, public: false)
+      urlpath = '/' + path
+      urlpath = urlpath + '?token=' + token if token
+      request = Net::HTTP::Get.new urlpath
+      unless public
+        request['X-Signature'] = KeyUtils.sign(@uri.to_s + urlpath, @priv_key) 
+        request['X-Identity'] = @pub_key
+      end
+      process_request(request)
+    end
+
+    def post(path:, token: nil, params:)
+      urlpath = '/' + path
+      request = Net::HTTP::Post.new urlpath
+      params[:token] = token if token
+      params[:guid]  = SecureRandom.uuid
+      params[:id] = @client_id
+      request.body = params.to_json
+      if token
+        request['X-Signature'] = KeyUtils.sign(@uri.to_s + urlpath + request.body, @priv_key)
+        request['X-Identity'] = @pub_key
+      end
+      process_request(request)
+    end
+
+    private
+
+    ## Processes HTTP Request and returns parsed response
+    # Otherwise throws error
+    #
+    def process_request(request)
+      request['User-Agent'] = @user_agent
+      request['Content-Type'] = 'application/json'
+      request['X-BitPay-Plugin-Info'] = 'Rubylib' + VERSION
+
+      begin
+        response = @https.request request
+      rescue => error
+        raise BitPay::ConnectionError, "#{error.message}"
+      end
+
+      if response.kind_of? Net::HTTPSuccess
+        return JSON.parse(response.body)["data"]
+      elsif JSON.parse(response.body)["error"]
+        raise(BitPayError, "#{response.code}: #{JSON.parse(response.body)['error']}")
+      else
+        raise BitPayError, "#{response.code}: #{JSON.parse(response.body)}"
+      end
+
+    end
+
+    ## Fetches the tokens hash from the server and
+    #  updates @tokens
+    #
+    def refresh_tokens
+      response = get(path: 'tokens')
+      token_array = response || {}
+      tokens = {}
+      token_array.each do |t|
+        tokens[t.keys.first] = t.values.first
+      end
+      @tokens = tokens
+      return tokens
+    end
+
+    ## Makes a request to /tokens for pairing
+    #     Adds passed params as post parameters
+    #     If empty params, retrieves server-generated pairing code
+    #     If pairingCode key/value is passed, will pair client ID to this account
+    #   Returns response hash
+    #
+
+    def get_token(facade)
+      token = @tokens[facade] || refresh_tokens[facade] || raise(BitPayError, "Not authorized for facade: #{facade}")
+    end
+
+  end
+end


### PR DESCRIPTION
The rest connector module moves most of the functionality of http
connection out of the client and into a module. The goal is to simplify
method calls and DRY up the code.

Changes include replacing all calls to send_request with calls to either
'get' or 'post'. process request now returns the "data" portion of the
JSON response from the server, as every method was retrieving that
separately.

removed some untested code.