### PR TITLE
add refunds and cucumber tests with documentation

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -154,6 +154,13 @@ client.get_all_refunds_for_invoice(id: 'PvVhgBfA7wKPWhuVC24rJo')
 # To get a specific refund for a specific invoice
 client.get_refund(id: 'JB49z2MsDH7FunczeyDS8j', request_id: '4evCrXq4EDXk4oqDXdWQhX')
 ```
+### Cancel Refund Requests
+
+Requires a `merchant` token.
+
+```ruby
+client.cancel_refund(id: 'JB49z2MsDH7FunczeyDS8j', request_id: '4evCrXq4EDXk4oqDXdWQhX')
+```
 
 ### Make a HTTP request directly against the REST API
 

--- a/config/capybara.rb
+++ b/config/capybara.rb
@@ -1,6 +1,6 @@
 Capybara.javascript_driver = :poltergeist
 Capybara.default_driver = :poltergeist
-Capybara.default_wait_time = 5
+Capybara.default_wait_time = 10
 Capybara.register_driver :poltergeist do |app|
 	Capybara::Poltergeist::Driver.new(app, timeout: 60, js_errors: false, phantomjs_options: ['--ignore-ssl-errors=yes', '--ssl-protocol=TLSv1', '--web-security=false'])
 end

--- a/config/constants.rb
+++ b/config/constants.rb
@@ -10,6 +10,10 @@ TEST_USER = ENV['RCTESTUSER']
 TEST_PASS = ENV['RCTESTPASSWORD']
 DASHBOARD_URL = "#{ROOT_ADDRESS}/dashboard/merchant/home"
 
+# Specify a bitpay txid which has 6+ confirmations.  Default belongs to 'bitpayrubyclient@gmail.com' test account
+REFUND_TRANSACTION = ENV['REFUND_TRANSACTION'] || 'TKKgh3LJuRXnq6hSR3hhNR'
+REFUND_ADDRESS = ENV['REFUND_ADDRESS'] || '2NCMQ8LRu71SfLMYTi8qotg6VRpBZynpFAh'  # Hamish's Testnet Copay Wallet
+
 unless
   ROOT_ADDRESS &&
   TEST_USER &&

--- a/features/creating_invoices.feature
+++ b/features/creating_invoices.feature
@@ -1,3 +1,4 @@
+@invoices
 Feature: creating an invoice
   The user won't get any money 
   If they can't
@@ -10,9 +11,10 @@ Feature: creating an invoice
     When the user creates an invoice for <price> <currency>
     Then they should recieve an invoice in response for <price> <currency>
   Examples:
-    | price    | currency |
-    | "5.23" | "USD"    |
+    | price   | currency |
+    | "5.23"  | "USD"    |
     | "10.21" | "EUR"    |
+    | "0.225" | "BTC"    |
 
   Scenario Outline: The invoice contains illegal characters
     When the user creates an invoice for <price> <currency>
@@ -20,7 +22,7 @@ Feature: creating an invoice
   Examples:
     | price    | currency  | message                              |
     | "5,023" | "USD"     | "Price must be formatted as a float" |
-    | "3.21" | "EaUR"    | "Currency is invalid."               |
+    | "3.21"  | "EaUR"    | "Currency is invalid."               |
     | ""       | "USD"     | "Price must be formatted as a float" |
     | "Ten"    | "USD"     | "Price must be formatted as a float" |
     | "10"    | ""        | "Currency is invalid."               |

--- a/features/pairing.feature
+++ b/features/pairing.feature
@@ -6,10 +6,10 @@ Feature: pairing with bitpay
   Scenario: the client has a correct pairing code
     Given the user pairs with BitPay with a valid pairing code
     Then the user is paired with BitPay
-    
+
   Scenario: the client initiates pairing
-    Given the user requests a client-side pairing
-    Then they will receive a claim code
+    Given the user performs a client-side pairing
+    Then the user has a merchant token
 
   Scenario Outline: the client has a bad pairing code
     Given the user fails to pair with a semantically <valid> code <code>

--- a/features/refunds.feature
+++ b/features/refunds.feature
@@ -1,0 +1,20 @@
+@refunds
+Feature: issuing a refund
+  The merchant wants to issue a refund
+  So that they can serve their customers
+
+  Scenario: creating a refund
+    Given the user creates a refund
+    Then they will receive a refund id
+  
+  Scenario: retrieving a refund
+    Given the user requests a specific refund
+    Then they will receive the refund 
+    
+  Scenario: retrieving all refunds
+    Given the user requests all refunds for an invoice
+    Then they will receive an array of refunds
+
+  Scenario: canceling a refund
+    Given a properly formatted cancellation request
+    Then the refund will be cancelled

--- a/features/retrieving_invoices.feature
+++ b/features/retrieving_invoices.feature
@@ -2,6 +2,10 @@ Feature: retrieving an invoice
   The user may want to retrieve invoices
   So that they can view them
 
-  Scenario: The request is correct
+  Scenario: Correct public request
     Given that a user knows an invoice id
-    Then they can retrieve that invoice
+    Then they can retrieve the public version of that invoice
+
+  Scenario: Correct merchant request
+    Given that a user knows an invoice id
+    Then they can retrieve the merchant-scoped version of that invoice    

--- a/features/step_definitions/invoice_steps.rb
+++ b/features/step_definitions/invoice_steps.rb
@@ -1,6 +1,6 @@
 When(/^the user (?:tries to |)creates? an invoice (?:for|without) "(.*?)" (?:or |and |)"(.*?)"$/) do |price, currency|
   begin
-    @response = @client.create_invoice(price: price, currency: currency)
+    @response = @client.create_invoice(price: price, currency: currency, facade: 'merchant')
    rescue => error
      @error = error
    end
@@ -15,12 +15,17 @@ Given(/^there is an invalid token$/) do
 end
 
 Given(/^that a user knows an invoice id$/) do
-  client = new_client_from_stored_values
-  @id = (client.create_invoice(price: 3, currency: "USD" ))['id']
+  @client = new_client_from_stored_values
+  @id = (@client.create_invoice(price: 3, currency: "USD", facade: 'merchant' ))['id']
 end
 
-Then(/^they can retrieve that invoice$/) do
-  invoice = BitPay::SDK::Client.new(api_uri: ROOT_ADDRESS, insecure: true).get_public_invoice(id: @id)
+Then(/^they can retrieve the public version of that invoice$/) do
+  invoice = @client.get_public_invoice(id: @id)
+  raise "That's the wrong invoice" unless invoice['id'] == @id
+end
+
+Then(/^they can retrieve the merchant\-scoped version of that invoice$/) do
+  invoice = @client.get_invoice(id: @id)
   raise "That's the wrong invoice" unless invoice['id'] == @id
 end
 

--- a/features/step_definitions/refund_steps.rb
+++ b/features/step_definitions/refund_steps.rb
@@ -1,0 +1,37 @@
+Given(/^the user creates a refund$/) do
+  client = new_client_from_stored_values
+  @response = client.refund_invoice(id: REFUND_TRANSACTION, params: {amount: 1, currency: 'USD', bitcoinAddress: REFUND_ADDRESS})
+end
+
+Then(/^they will receive a refund id$/) do
+  @refund_id = @response["id"]
+  expect(@refund_id).not_to be_empty
+end
+
+Given(/^the user requests a specific refund$/) do
+  client = new_client_from_stored_values
+  @response = client.get_refund(id: REFUND_TRANSACTION, request_id: @refund_id)
+end
+
+Then(/^they will receive the refund$/) do
+  expect(@response.first["status"]).not_to be_empty
+end
+
+Given(/^the user requests all refunds for an invoice$/) do
+  client = new_client_from_stored_values
+  @response = client.get_all_refunds_for_invoice(id: REFUND_TRANSACTION)
+end
+
+Then(/^they will receive an array of refunds$/) do
+  expect(@response).to be_instance_of Array
+end
+
+Given(/^a properly formatted cancellation request$/) do
+  client = new_client_from_stored_values
+  @refund_id = client.get_all_refunds_for_invoice(id: REFUND_TRANSACTION).first["id"]
+  @response = client.cancel_refund(id: REFUND_TRANSACTION, request_id: @refund_id)
+end
+
+Then(/^the refund will be cancelled$/) do
+  expect(@response).to eq("Success")
+end

--- a/lib/bitpay/client.rb
+++ b/lib/bitpay/client.rb
@@ -69,12 +69,77 @@ module BitPay
         post(path: "invoices", token: token, params: params)
       end
 
+      ## Gets the privileged merchant-version of the invoice		
+      #   Requires merchant facade token		
+      #		
+      def get_invoice(id:)
+        token = get_token('merchant')
+        get(path: "invoices/#{id}", token: token)
+      end
+
       ## Gets the public version of the invoice
       #
       def get_public_invoice(id:)
         get(path: "invoices/#{id}", public: true)
       end
       
+      
+      ## Refund paid BitPay invoice
+      #
+      #   If invoice["data"]["flags"]["refundable"] == true the a refund address was 
+      #   provided with the payment and the refund_address parameter is an optional override
+      #  
+      #   Amount and Currency are required fields for fully paid invoices but optional
+      #   for under or overpaid invoices which will otherwise be completely refunded
+      #
+      #   Requires merchant facade token
+      #
+      #  @example
+      #    client.refund_invoice(id: 'JB49z2MsDH7FunczeyDS8j', params: {amount: 10, currency: 'USD', bitcoinAddress: '1Jtcygf8W3cEmtGgepggtjCxtmFFjrZwRV'})
+      #
+      def refund_invoice(id:, params:{})
+        invoice = get_invoice(id: id)
+        post(path: "invoices/#{id}/refunds", token: invoice["token"], params: params)
+      end
+      
+      ## Get All Refunds for Invoice
+      #   Returns an array of all refund requests for a specific invoice, 
+      # 
+      #   Requires merchant facade token
+      #
+      #  @example:
+      #    client.get_all_refunds_for_invoice(id: 'JB49z2MsDH7FunczeyDS8j')
+      #
+      def get_all_refunds_for_invoice(id:)
+        urlpath = "invoices/#{id}/refunds"
+        invoice = get_invoice(id: id)
+        get(path: urlpath, token: invoice["token"])
+      end
+
+      ## Get Refund
+      #   Requires merchant facade token
+      #
+      #  @example:
+      #    client.get_refund(id: 'JB49z2MsDH7FunczeyDS8j', request_id: '4evCrXq4EDXk4oqDXdWQhX')
+      #
+      def get_refund(id:, request_id:)
+        urlpath = "invoices/#{id}/refunds/#{request_id}"
+        invoice = get_invoice(id: id)
+        get(path: urlpath, token: invoice["token"])
+      end
+      
+      ## Cancel Refund
+      #   Requires merchant facade token
+      #
+      #  @example:
+      #    client.cancel_refund(id: 'JB49z2MsDH7FunczeyDS8j', request_id: '4evCrXq4EDXk4oqDXdWQhX')
+      #
+      def cancel_refund(id:, request_id:)
+        urlpath = "invoices/#{id}/refunds/#{request_id}"
+        refund = get_refund(id: id, request_id: request_id)
+        delete(path: urlpath, token: refund["token"])
+      end      
+
       ## Checks that the passed tokens are valid by
       #  comparing them to those that are authorized by the server
       #

--- a/lib/bitpay/client.rb
+++ b/lib/bitpay/client.rb
@@ -62,7 +62,10 @@ module BitPay
       #   Defaults to pos facade, also works with merchant facade
       # 
       def create_invoice(price:, currency:, facade: 'pos', params:{})
-        raise BitPay::ArgumentError, "Illegal Argument: Price must be formatted as a float" unless ( price.is_a?(Numeric) || /^[[:digit:]]+(\.[[:digit:]]{2})?$/.match(price) )
+        raise BitPay::ArgumentError, "Illegal Argument: Price must be formatted as a float" unless 
+          price.is_a?(Numeric) ||
+          /^[[:digit:]]+(\.[[:digit:]]{2})?$/.match(price) ||
+          currency == 'BTC' && /^[[:digit:]]+(\.[[:digit:]]{1,6})?$/.match(price)
         raise BitPay::ArgumentError, "Illegal Argument: Currency is invalid." unless /^[[:upper:]]{3}$/.match(currency)
         params.merge!({price: price, currency: currency})
         token = get_token(facade)

--- a/lib/bitpay/rest_connector.rb
+++ b/lib/bitpay/rest_connector.rb
@@ -11,8 +11,6 @@ module BitPay
         return get(path: path, token: token)
       when "POST"
         return post(path: path, token: token, params: params)
-      when "DELETE"
-        return delete(path: path, token: token)
       else
         raise(BitPayError, "Invalid HTTP verb: #{verb.upcase}")
       end

--- a/lib/bitpay/rest_connector.rb
+++ b/lib/bitpay/rest_connector.rb
@@ -8,9 +8,11 @@ module BitPay
       token ||= get_token(facade)
       case verb.upcase
       when "GET"
-        return get(path: path, token:token)
+        return get(path: path, token: token)
       when "POST"
         return post(path: path, token: token, params: params)
+      when "DELETE"
+        return delete(path: path, token: token)
       else
         raise(BitPayError, "Invalid HTTP verb: #{verb.upcase}")
       end
@@ -38,6 +40,15 @@ module BitPay
         request['X-Signature'] = KeyUtils.sign(@uri.to_s + urlpath + request.body, @priv_key)
         request['X-Identity'] = @pub_key
       end
+      process_request(request)
+    end
+
+    def delete(path:, token: nil)
+      urlpath = '/' + path
+      urlpath = urlpath + '?token=' + token if token
+      request = Net::HTTP::Delete.new urlpath
+      request['X-Signature'] = KeyUtils.sign(@uri.to_s + urlpath, @priv_key) 
+      request['X-Identity'] = @pub_key
       process_request(request)
     end
 

--- a/spec/fixtures/invoices_{id}_refunds_{refund_id}-GET.json
+++ b/spec/fixtures/invoices_{id}_refunds_{refund_id}-GET.json
@@ -1,9 +1,11 @@
 {
   "facade": "merchant/supportRequest",
-  "data": {
-    "id": "TEST_REQUEST_ID",
-    "requestDate": "2015-01-27T00:36:12.360Z",
-    "status": "pending",
-    "token": "REFUND_REQUEST_TOKEN"
-  }
+  "data": [
+    {
+      "id": "TEST_REQUEST_ID",
+      "requestDate": "2015-01-27T00:36:12.360Z",
+      "status": "pending",
+      "token": "REFUND_REQUEST_TOKEN"
+    }
+  ]
 }


### PR DESCRIPTION
Re-adds refunds capability with associated feature specs.  Also adds "cancel_refund" method and associated documentation.

As a side effect, the tests now request and store a merchant token, under the `new_client_from_stored_values` method

Testing refunds requires a pre-seeded transaction with 6+ transactions.  This has been created under the bitpayrubyclient@gmail.com test account and specified in constants.rb.  This can be overridden by setting the `REFUND_TRANSACTION` environment variable to a qualified transaction belonging to a different test user.

If you want to use the defaults, just use
```
source ./spec/set_constants.sh https://test.bitpay.com bitpayrubyclient@gmail.com Bc*#Qlz2JPK2
```
to pre-wire your test environment