### PR TITLE
Allow newer versions of gem dependencies

### DIFF
--- a/bitpay-sdk.gemspec
+++ b/bitpay-sdk.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_dependency 'json',      '1.8.1'
-  s.add_dependency 'rack',      '1.5.2'
-  s.add_dependency 'ecdsa',     '1.2.0'
+  s.add_dependency 'json',      '~>1.8'
+  s.add_dependency 'rack',      '~>1.5'
+  s.add_dependency 'ecdsa',     '~>1.2'
 
   s.add_development_dependency 'rake', '10.3.2'
   s.add_development_dependency 'webmock', '1.18.0'


### PR DESCRIPTION
Rack is now 1.6.0 & json is at 1.8.2; hard dependencies force downgrade of these gems.