### PR TITLE
Bump rack to unblock rails 4.2

### DIFF
--- a/bitpay-sdk.gemspec
+++ b/bitpay-sdk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.add_dependency 'json',      '~>1.8'
-  s.add_dependency 'rack',      '~>1.5'
+  s.add_dependency 'rack',      '~>1.6'
   s.add_dependency 'bitpay-key-utils', '~>2.0.0'
 
   s.add_development_dependency 'rake', '10.3.2'


### PR DESCRIPTION
    bitpay-client (>= 2.2.0) ruby depends on
      rack (~> 1.5.2) ruby

    rails (>= 4.2.1) ruby depends on
      railties (= 4.2.1) ruby depends on
        actionpack (= 4.2.1) ruby depends on
          rack (~> 1.6) ruby