### PR TITLE
Do not set a guid param during POST. 

### DIFF
--- a/lib/bitpay/rest_connector.rb
+++ b/lib/bitpay/rest_connector.rb
@@ -32,7 +32,6 @@ module BitPay
       urlpath = '/' + path
       request = Net::HTTP::Post.new urlpath
       params[:token] = token if token
-      params[:guid]  = SecureRandom.uuid
       params[:id] = @client_id
       request.body = params.to_json
       if token


### PR DESCRIPTION
The API seems to behave the same if a different guid is provided every time (the previous client behavior) or if no guid is provided.

Creating a random guid for every POST request breaks the idempotency intent of the API by making every POST unique and makes creating a reliable application very difficult.
