### PR TITLE
Allow new rack v2 for Rails 5 apps

### DIFF
--- a/bitpay-sdk.gemspec
+++ b/bitpay-sdk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.add_dependency 'json',      '~>1.8'
-  s.add_dependency 'rack',      '~>1.5'
+  s.add_dependency 'rack',      '>= 1.4', (RUBY_VERSION < '2.2.2' ? '< 2' : '< 3')
   s.add_dependency 'bitpay-key-utils', '~>2.0.0'
 
   s.add_development_dependency 'rake', '10.3.2'


### PR DESCRIPTION
Rails 5 now requires Rack 2 which in turn requires Ruby 2.2.2 and up. This update still allows Rack 1 on older Ruby versions that aren't compatible with Rack 2 but then support upgrading.