### PR TITLE
Fix Travis failure on nil ENV['BITPAYPEM']

### DIFF
--- a/config/constants.rb
+++ b/config/constants.rb
@@ -6,6 +6,7 @@
 #
 
 APIURI = ENV['BITPAYAPI']
+PEM = ENV['BITPAYPEM'] || "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEICg7E4NN53YkaWuAwpoqjfAofjzKI7Jq1f532dX+0O6QoAcGBSuBBAAK\noUQDQgAEjZcNa6Kdz6GQwXcUD9iJ+t1tJZCx7hpqBuJV2/IrQBfue8jh8H7Q/4vX\nfAArmNMaGotTpjdnymWlMfszzXJhlw==\n-----END EC PRIVATE KEY-----\n"
 
 # Specify a bitpay txid which has 6+ confirmations.  Default belongs to 'bitpayrubyclient@gmail.com' test account
 REFUND_TRANSACTION = ENV['REFUND_TRANSACTION']

--- a/features/step_definitions/step_helpers.rb
+++ b/features/step_definitions/step_helpers.rb
@@ -15,7 +15,7 @@ module BitPay
 end
 
 def new_client_from_stored_values
-  pem = ENV['BITPAYPEM'].gsub("\\n", "\n")
+  pem = PEM.gsub("\\n", "\n")
   BitPay::SDK::Client.new(api_uri: APIURI, pem: pem, insecure: true)
 end
 


### PR DESCRIPTION
The commit 671fe5657b3558c242fa2367e979c3d9ca571b2b introduced (a new ENV['BITPAYPEM'])[https://github.com/bitpay/ruby-client/commit/671fe5657b3558c242fa2367e979c3d9ca571b2b#diff-2fbdf6e6f53a9bb9a2c06059507373a8R18] but it wasn't defined anywhere. There is already (a constant called `PEM` in the `spec_helper.rb` file)[https://github.com/bitpay/ruby-client/blob/master/spec/spec_helper.rb#L12] so figured it should just use that. This could be moved to the constants config file instead if preferred and use the ENV variable and default to a value if ENV variable is nil.