### PR TITLE
Remove unnecessary rack/json dependencies

### DIFF
--- a/bitpay-sdk.gemspec
+++ b/bitpay-sdk.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_dependency 'json',      '~>1.8'
-  s.add_dependency 'rack',      '~>1.5'
   s.add_dependency 'bitpay-key-utils', '~>2.0.0'
 
   s.add_development_dependency 'rake', '10.3.2'

--- a/bitpay-sdk.gemspec
+++ b/bitpay-sdk.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bitpay-key-utils', '~>2.0.0'
 
+  s.add_development_dependency 'rack', '~>1.5'
   s.add_development_dependency 'rake', '10.3.2'
   s.add_development_dependency 'webmock', '1.18.0'
   s.add_development_dependency 'pry', '0.10.1'


### PR DESCRIPTION
Rack isn't used at all so no need to specify. Based on [this comment](https://github.com/bitpay/ruby-client/pull/51#issuecomment-236736392) this seems to be carried over from a Rails app so is safe to remove. This will also allow this gem to be used in Rails 5 apps which now require Rack v2.

No need to specify json dependency since this gem requires Ruby 2.0+ and I've [seen this change made elsewhere](https://github.com/mperham/sidekiq/issues/2743) to clean up dependencies and also support other platforms (Windows). The json library is being required in `lib/bitpay/client.rb`.